### PR TITLE
Fix: Address various Dart analyzer errors

### DIFF
--- a/lib/presentation/pages/settings_screen.dart
+++ b/lib/presentation/pages/settings_screen.dart
@@ -216,21 +216,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
       }
       
       // Si on arrive ici, c'est que la connexion a réussi
+      String connectionMessage = 'Connexion réussie! Nom du site: ${siteName ?? "Non défini"}\n';
+
+      // Ajouter la puissance crête si disponible
+      if (peakPower != null) {
+        connectionMessage += 'Puissance crête: ${peakPower.toStringAsFixed(2)} kW\n';
+      }
+
+      // Ajouter les coordonnées si disponibles
+      if (latitude != null && longitude != null) {
+        connectionMessage += 'Latitude: ${latitude.toStringAsFixed(4)}, Longitude: ${longitude.toStringAsFixed(4)}\n';
+      }
+
       setState(() {
         _siteName = siteName;
         _sitePeakPower = peakPower;
         _testConnectionSuccess = true;
-        _testConnectionResult = 'Connexion réussie! Nom du site: ${siteName ?? "Non défini"}\n';
-        
-        // Ajouter la puissance crête si disponible
-        if (peakPower != null) {
-          _testConnectionResult += 'Puissance crête: ${peakPower.toStringAsFixed(2)} kW\n';
-        }
-        
-        // Ajouter les coordonnées si disponibles
-        if (latitude != null && longitude != null) {
-          _testConnectionResult += 'Latitude: ${latitude.toStringAsFixed(4)}, Longitude: ${longitude.toStringAsFixed(4)}\n';
-        }
+        _testConnectionResult = connectionMessage;
         
         // Sauvegarder les coordonnées du site pour une utilisation future
         _saveSiteCoordinates(latitude, longitude, siteName, peakPower);

--- a/lib/presentation/widgets/daily_production_chart.dart
+++ b/lib/presentation/widgets/daily_production_chart.dart
@@ -39,8 +39,8 @@ class _DailyProductionChartState extends State<DailyProductionChart> {
         lineTouchData: LineTouchData(
           touchTooltipData: LineTouchTooltipData(
             // --- CORRECTION : tooltipBgColor déplacé ici ---
-            get tooltipBgColor => AppTheme.cardColor.withOpacity(0.8);
-            get tooltipRoundedRadius => 8;
+            tooltipBgColor: AppTheme.cardColor.withOpacity(0.8), // Corrected syntax
+            tooltipRoundedRadius: 8,
             getTooltipItems: (List<LineBarSpot> touchedSpots) {
               return touchedSpots
                   .map((spot) {

--- a/test/assistant_service_test.dart
+++ b/test/assistant_service_test.dart
@@ -38,6 +38,11 @@ class FakeUserPreferences implements UserPreferences {
   String? _fakePanelOrientation;
   double? _fakeWashingMachineKw;
   int? _fakeDefaultWashingMachineDurationMin; // Added for the new field
+  // New fields for dryer and washing machine 2
+  double? _fakeDryerKw;
+  int? _fakeDefaultDryerDurationMin;
+  double? _fakeWashingMachine2Kw;
+  int? _fakeDefaultWashingMachine2DurationMin;
   double? _fakeLatitude;
   double? _fakeLongitude;
 
@@ -101,6 +106,27 @@ class FakeUserPreferences implements UserPreferences {
   @override
   set defaultWashingMachineDurationMin(int? value) => _fakeDefaultWashingMachineDurationMin = value;
 
+  // Getters and Setters for new fields
+  @override
+  double? get dryerKw => _fakeDryerKw;
+  @override
+  set dryerKw(double? value) => _fakeDryerKw = value;
+
+  @override
+  int? get defaultDryerDurationMin => _fakeDefaultDryerDurationMin;
+  @override
+  set defaultDryerDurationMin(int? value) => _fakeDefaultDryerDurationMin = value;
+
+  @override
+  double? get washingMachine2Kw => _fakeWashingMachine2Kw;
+  @override
+  set washingMachine2Kw(double? value) => _fakeWashingMachine2Kw = value;
+
+  @override
+  int? get defaultWashingMachine2DurationMin => _fakeDefaultWashingMachine2DurationMin;
+  @override
+  set defaultWashingMachine2DurationMin(int? value) => _fakeDefaultWashingMachine2DurationMin = value;
+
 
   FakeUserPreferences({
     this.solarEdgeApiKey,
@@ -119,6 +145,11 @@ class FakeUserPreferences implements UserPreferences {
     String? panelOrientation,
     double? washingMachineKw,
     int? defaultWashingMachineDurationMin, // Added
+    // New fields in constructor
+    double? dryerKw,
+    int? defaultDryerDurationMin,
+    double? washingMachine2Kw,
+    int? defaultWashingMachine2DurationMin,
     double? latitude,
     double? longitude,
     this.weatherLocationSource = 'site_primary',
@@ -131,6 +162,11 @@ class FakeUserPreferences implements UserPreferences {
        _fakePanelOrientation = panelOrientation,
        _fakeWashingMachineKw = washingMachineKw,
        _fakeDefaultWashingMachineDurationMin = defaultWashingMachineDurationMin, // Added
+       // Initialize new fields
+       _fakeDryerKw = dryerKw,
+       _fakeDefaultDryerDurationMin = defaultDryerDurationMin,
+       _fakeWashingMachine2Kw = washingMachine2Kw,
+       _fakeDefaultWashingMachine2DurationMin = defaultWashingMachine2DurationMin,
        _fakeLatitude = latitude,
        _fakeLongitude = longitude,
        selectedLanguage = selectedLanguage; // Initialize the final field
@@ -154,6 +190,11 @@ class FakeUserPreferences implements UserPreferences {
     String? panelOrientation,
     double? washingMachineKw,
     int? defaultWashingMachineDurationMin, // Added
+    // New fields for copyWith
+    double? dryerKw,
+    int? defaultDryerDurationMin,
+    double? washingMachine2Kw,
+    int? defaultWashingMachine2DurationMin,
     double? latitude,
     double? longitude,
     String? weatherLocationSource,
@@ -175,6 +216,11 @@ class FakeUserPreferences implements UserPreferences {
       panelOrientation: panelOrientation ?? this._fakePanelOrientation,
       washingMachineKw: washingMachineKw ?? this._fakeWashingMachineKw,
       defaultWashingMachineDurationMin: defaultWashingMachineDurationMin ?? this._fakeDefaultWashingMachineDurationMin, // Added
+      // Pass new fields to copyWith
+      dryerKw: dryerKw ?? this._fakeDryerKw,
+      defaultDryerDurationMin: defaultDryerDurationMin ?? this._fakeDefaultDryerDurationMin,
+      washingMachine2Kw: washingMachine2Kw ?? this._fakeWashingMachine2Kw,
+      defaultWashingMachine2DurationMin: defaultWashingMachine2DurationMin ?? this._fakeDefaultWashingMachine2DurationMin,
       latitude: latitude ?? this._fakeLatitude,
       longitude: longitude ?? this._fakeLongitude,
       weatherLocationSource: weatherLocationSource ?? this.weatherLocationSource,


### PR DESCRIPTION
- Correct null safety issues in settings_screen.dart.
- Fix syntax error for tooltipBgColor in daily_production_chart.dart.
- Update FakeUserPreferences in assistant_service_test.dart to implement new fields from UserPreferences (related to dryer and second washing machine) and correct the copyWith method signature.
- Assumed that other reported errors in chart files (fl_chart related) were stale as fixes were already present in the codebase.